### PR TITLE
[WIP] Add create PR script for kudos

### DIFF
--- a/notifier/create-pull.py
+++ b/notifier/create-pull.py
@@ -1,0 +1,12 @@
+import requests, json
+from github import Github
+
+def handle(req):
+
+    kudo_data = json.loads(req)
+
+    g = Github(kudo_data["auth"])
+    repo = g.get_repo(kudo_data["repo"])
+    pull = repo.create_pull("Accept Kudo Badge from " + kudo_data["maintainer"], kudo_data["kudo-body"])
+
+    return pull.json()


### PR DESCRIPTION
A preffered approach is to open a PR in user's github.io repo
instead of sending e-mail. This should be automated.
Authentication needs to be resolved.

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>